### PR TITLE
feat: Rule Taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # fmlint
 Front Matter Lint:  Lint your Markdown Front Matter
+
+
+## Rule IDs
+Each lint rule is identified with a `rule-id`.  You can find a list of all `rule-id`s, with the `list` command:
+
+```
+fmlint list
+```
+### Developer Info
+Rules, within this program, are identified by

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -13,7 +13,7 @@ import (
 // When the function is called, it expects a boolean value indicating whether
 // or not an error occurred.
 func handleErrors(hasError bool) {
-	warn := viper.GetString("warn")
+	warn := viper.GetViper().GetString("warn")
 	if hasError && warn != "true" {
 		os.Exit(1)
 	}
@@ -30,9 +30,10 @@ func handleErrors(hasError bool) {
 // If the rule is disabled, it returns false.
 // If the rule is enabled, it returns true.
 func ruleEnabled(ruleID string) bool {
-	config := viper.GetStringSlice("disabled_rules")
+	config := viper.GetViper().GetStringSlice("disabled_rules")
 	for _, rule := range config {
 		if rule == ruleID {
+			log.Printf("Rule \"%s\" is disabled, not linting", ruleID)
 			return false
 		}
 	}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -22,3 +22,19 @@ func handleErrors(hasError bool) {
 	}
 
 }
+
+// ruleEnabled checks if a rule is enabled.
+// It expects a rule ID as input.
+// Rules are always enabled unless disabled in the config file.
+// Rules are disabled if they are in the yaml config file in the map "disabled_rules"."
+// If the rule is disabled, it returns false.
+// If the rule is enabled, it returns true.
+func ruleEnabled(ruleID string) bool {
+	config := viper.GetStringSlice("disabled_rules")
+	for _, rule := range config {
+		if rule == ruleID {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,14 +18,15 @@ var listCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		//Get all commands
 		cmdList := cmd.Parent().Commands()
-		fmt.Printf("%s \t %s \t\t\t %s\n", "Command", "Short", "Rule-ID")
-
+		fmt.Printf("%s \t %s \t\t %s\n", "Command", "Short Description", "Rule-ID")
+		//print a separator
+		fmt.Println("------------------------------------------------------------")
 		for _, command := range cmdList {
 			//Print command name
 			if command.Annotations != nil {
 				//If command.Annotations has key "rule-id", print it
 				if _, ok := command.Annotations["rule-id"]; ok {
-					fmt.Printf("%s \t %s \t %s\n", command.Name(), command.Short, command.Annotations["rule-id"])
+					fmt.Printf("%s \t\t %s \t\t %s\n", command.Name(), command.Short, command.Annotations["rule-id"])
 				}
 			}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var lintRule struct {
+	Rule map[string]string
+}
+
+// listCmd represents the list command
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List lint rules",
+	Long:  `Lists all commands and their corresponding lint rules.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		//Get all commands
+		cmdList := cmd.Parent().Commands()
+		fmt.Printf("%s \t %s \t\t\t %s\n", "Command", "Short", "Rule-ID")
+
+		for _, command := range cmdList {
+			//Print command name
+			if command.Annotations != nil {
+				//If command.Annotations has key "rule-id", print it
+				if _, ok := command.Annotations["rule-id"]; ok {
+					fmt.Printf("%s \t %s \t %s\n", command.Name(), command.Short, command.Annotations["rule-id"])
+				}
+			}
+
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(listCmd)
+
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -8,9 +8,10 @@ import (
 
 // listCmd represents the list command
 var listCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List lint rules",
-	Long:  `Lists all commands and their corresponding lint rules.`,
+	Use:         "list",
+	Short:       "List lint rules",
+	Annotations: map[string]string{"rule-id": "none"},
+	Long:        `Lists all commands and their corresponding lint rules.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		//Get all commands
 		cmdList := cmd.Parent().Commands()
@@ -18,10 +19,14 @@ var listCmd = &cobra.Command{
 		//print a separator
 		fmt.Println("------------------------------------------------------------")
 		for _, command := range cmdList {
-			//Print command name
+
 			if command.Annotations != nil {
 				//If command.Annotations has key "rule-id", print it
 				if _, ok := command.Annotations["rule-id"]; ok {
+					if command.Annotations["rule-id"] == "none" {
+						//If rule-id is none, skip it
+						continue
+					}
 					fmt.Printf("%s \t\t %s \t\t %s\n", command.Name(), command.Short, command.Annotations["rule-id"])
 				}
 			}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,10 +6,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var lintRule struct {
-	Rule map[string]string
-}
-
 // listCmd represents the list command
 var listCmd = &cobra.Command{
 	Use:   "list",

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -7,7 +7,7 @@ import (
 // This test is not specific to list.go.  All commands added to this program
 // should have a rule-id annotation.  In the case that a  command does not have
 // a "categorizable" rule, rule-id should be annotated with "none".
-func TestMain(t *testing.T) {
+func Test_rule_id_annotations(t *testing.T) {
 	cmdList := rootCmd.Commands()
 	for _, command := range cmdList {
 		//Print command name

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -12,7 +12,6 @@ func TestMain(t *testing.T) {
 	for _, command := range cmdList {
 		//Print command name
 		ruleID := command.Annotations["rule-id"]
-		println(ruleID)
 		if ruleID == "" {
 			t.Errorf("command %s has no rule-id annotation", command.Name())
 			t.Fail()

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+var testCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test Command",
+	Long: `This is only a test command and is not added to the root command,
+	outside of the test context.
+	The only purpose for this command is to test the rule-id annotation.`,
+	Run: func(cmd *cobra.Command, args []string) {
+	}}
+
+func init() {
+	rootCmd.AddCommand(testCmd)
+}
+
+// This test is not specific to list.go.  All commands added to this program
+// should have a rule-id annotation.  In the case that a  command does not have
+// a "categorizable" rule, rule-id should be annotated with "none".
+func TestMain(t *testing.T) {
+	cmdList := rootCmd.Commands()
+	for _, command := range cmdList {
+		//Print command name
+		ruleID := command.Annotations["rule-id"]
+		println(ruleID)
+		if ruleID == "" {
+			t.Errorf("command %s has no rule-id annotation", command.Name())
+			t.Fail()
+		}
+	}
+
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -2,22 +2,7 @@ package cmd
 
 import (
 	"testing"
-
-	"github.com/spf13/cobra"
 )
-
-var testCmd = &cobra.Command{
-	Use:   "test",
-	Short: "Test Command",
-	Long: `This is only a test command and is not added to the root command,
-	outside of the test context.
-	The only purpose for this command is to test the rule-id annotation.`,
-	Run: func(cmd *cobra.Command, args []string) {
-	}}
-
-func init() {
-	rootCmd.AddCommand(testCmd)
-}
 
 // This test is not specific to list.go.  All commands added to this program
 // should have a rule-id annotation.  In the case that a  command does not have

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -66,7 +67,7 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize()
+	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.fmlint.yaml)")
 	rootCmd.PersistentFlags().StringP("folder", "f", "./content", "Folder to recursively scan for frontmatter markdown files.")
 	rootCmd.PersistentFlags().BoolP("warn-only", "", false, "Do not fail if errors are encountered, but print warnings.")
@@ -75,4 +76,29 @@ func init() {
 	//nolint:errcheck
 	viper.BindPFlag("warn", rootCmd.PersistentFlags().Lookup("warn-only"))
 
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" {
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		// Search config in home directory with name ".fmlint.yaml"
+		viper.AddConfigPath(home)
+		viper.SetConfigType("yaml")
+		viper.SetConfigName(".fmlint")
+	}
+
+	viper.AutomaticEnv() // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		log.Printf("Using config file: %s", viper.ConfigFileUsed())
+
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,7 +67,6 @@ func Execute() {
 
 func init() {
 	cobra.OnInitialize()
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.fmlint.yaml)")
 	rootCmd.PersistentFlags().StringP("folder", "f", "./content", "Folder to recursively scan for frontmatter markdown files.")
 	rootCmd.PersistentFlags().BoolP("warn-only", "", false, "Do not fail if errors are encountered, but print warnings.")

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -19,9 +19,9 @@ func init() {
 var tagsCmd = &cobra.Command{
 	Use:         "tags",
 	Annotations: map[string]string{"rule-id": "tags-sorted"},
-	Short:       "Lint tags in frontmatter",
-	Long: `Tags are expected to be a YAML list.
-	This subcommand checks to ensure they are sorted alphabetically.`,
+	Short:       "Lint tag sorting",
+	Long: `Tags in frontmatter are expected to be a YAML list.
+	This command checks to ensure they are sorted alphabetically.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		hasErr := false
 		//recursively walk the "content" directory and find all the files

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -52,7 +52,6 @@ var tagsCmd = &cobra.Command{
 // Returns true if sorted, false if not.
 func checkTags(file string) bool {
 	var matter struct {
-		Name string   `yaml:"name"`
 		Tags []string `yaml:"tags"`
 	}
 	b, err := os.ReadFile(file)

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -41,6 +41,10 @@ var tagsCmd = &cobra.Command{
 				}
 				return nil
 			})
+		// TODO Reconcile this,
+		// when a rule is disabled handleErrors should not be called.
+		// Since handleErrors would also be responsible for warning if a rule caught errors,
+		// it is not neccessary to call handleErrors here in such case that a rule is disabled.
 		if err != nil && ruleEnabled("tags-sorted") {
 			log.Println(err)
 		}

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -41,7 +41,7 @@ var tagsCmd = &cobra.Command{
 				}
 				return nil
 			})
-		if err != nil {
+		if err != nil && ruleEnabled("tags-sorted") {
 			log.Println(err)
 		}
 		handleErrors(hasErr)

--- a/cmd/tags.go
+++ b/cmd/tags.go
@@ -17,8 +17,9 @@ func init() {
 }
 
 var tagsCmd = &cobra.Command{
-	Use:   "tags",
-	Short: "Lint tags in frontmatter",
+	Use:         "tags",
+	Annotations: map[string]string{"rule-id": "tags-sorted"},
+	Short:       "Lint tags in frontmatter",
 	Long: `Tags are expected to be a YAML list.
 	This subcommand checks to ensure they are sorted alphabetically.`,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/tags_test.go
+++ b/cmd/tags_test.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"log"
+	"os"
 	"testing"
 )
 
 // Checks that a file with properly sorted tags passes.
 func Test_passing_checkTags(t *testing.T) {
+
 	if checkTags("../test/tags_pass.md") == false {
 		t.Error("Expected tags_pass.md to pass but it failed")
 		t.Fail()
@@ -14,6 +17,9 @@ func Test_passing_checkTags(t *testing.T) {
 
 // Checks that a file with improperly sorted tags fails.
 func Test_failing_checkTags(t *testing.T) {
+	// Redirect log output to /dev/null to avoid test result pollution.
+	null, _ := os.Open(os.DevNull)
+	log.SetOutput(null)
 	if checkTags("../test/tags_fail.md") == true {
 		t.Error("Expected tags_fail.md to fail but it passed")
 		t.Fail()


### PR DESCRIPTION
Introduce a rule taxonomy through the use of Annotations on any `cobra.Command`.  This establishes two patterns for the future of the project:  
- All lint rules will be introduced as a `cobra.Command`, or groups of them (e.g. right now "tags" is implemented for something specific, in the future "tags" may be all lint rules related to tags)
- All instances of `cobra.Command` within the project **must** have an Annotation which contains `rule-id`.  