### PR TITLE
feat: lint all

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ This expects a directory structure which has Markdown with [Front Matter](https:
 
 Using a command identified by [`fmlint list`](#rule-ids), you can then use than lint rule using `fmlint lint <command>`
 
+### Usage - Disabling Lint Rules
+To disable a lint rule, configure a `yaml` file with a list of [`rule-id`s](#rule-ids) which you want to disable from checking.  
+#### Example
+config.yaml
+```yaml
+disabled_rules:
+  - "tags-sorted"
+  - "draft-enabled"
+```
+
+Then, pass this in execution, e.g. `fmlint lint all --config config.yaml`.  
 
 ## Usage - Github Actions
 This tool is **built** with CI environments in mind.  

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -101,7 +102,12 @@ func evaluateRules(fn lintRule) {
 		})
 	//Handle errors from the filepath walk
 	if err != nil {
+		if strings.HasSuffix(err.Error(), ": no such file or directory") {
+			log.Printf("Error: Directory %s does not exist", folder)
+			os.Exit(1)
+		}
 		log.Println(err)
+
 	}
 	//Handle errors from the lint function, if more than zero errors are present
 	handleErrors(hasErr)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-*/
 package cmd
 
 import (
@@ -28,6 +25,12 @@ var lintCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		}
+		// if all was specified,
+		if cmd.CalledAs() == "lint all" {
+			//lint all
+			println("hello world")
+
+		}
 	},
 }
 
@@ -38,17 +41,27 @@ func init() {
 // handleErrors checks if any errors occurred during the execution of the command.
 // If so, it prints the error message and exits the program.
 // If --warn-only is set, it prints the error message and continues.
+// If lint was called with "lint all", it does not exit and returns an error instead.
 // When the function is called, it expects a boolean value indicating whether
 // or not an error occurred.
 func handleErrors(hasError bool) {
 	warn := viper.GetViper().GetString("warn")
-	if hasError && warn != "true" {
+	//lint_all only is set by allCmd.
+	lint_all := viper.GetViper().GetBool("lint_all")
+	if hasError && !lint_all && warn != "true" {
 		os.Exit(1)
 	}
 	if hasError && warn == "true" {
 		log.Println("Warning: 1 or more errors occurred but --warn-only is set.")
 	}
-
+	if hasError && lint_all {
+		// Special viper setting used internally.  Not exposed as a flag.
+		// While it could technically be used through a config file,
+		// it would be abnormal and not as-designed.
+		// If lint_all is set, it is considered a "soft" failure per-rule, but then
+		// allCmd will register the failure and exit abnormally.
+		viper.Set("lint_all_fail", true)
+	}
 }
 
 // ruleEnabled checks if a rule is enabled.

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -25,12 +25,6 @@ var lintCmd = &cobra.Command{
 			cmd.Help()
 			os.Exit(1)
 		}
-		// if all was specified,
-		if cmd.CalledAs() == "lint all" {
-			//lint all
-			println("hello world")
-
-		}
 	},
 }
 

--- a/cmd/lint_all.go
+++ b/cmd/lint_all.go
@@ -33,13 +33,4 @@ var allCmd = &cobra.Command{
 func init() {
 	lintCmd.AddCommand(allCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// allCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// allCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/lint_all.go
+++ b/cmd/lint_all.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// allCmd represents the all command
+var allCmd = &cobra.Command{
+	Use:         "all",
+	Annotations: map[string]string{"rule-id": "none"},
+	Short:       "Run all lint commands.",
+	Long:        ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		viper.Set("lint_all", true)
+		//RUn all commands with rule-id annotation.
+		cmdList := lintCmd.Commands()
+		for _, command := range cmdList {
+			if command.Annotations["rule-id"] != "none" {
+				command.Run(cmd, args)
+			}
+
+		}
+		// If a failure was encountered and recorded by handleError, exit.
+		if viper.GetBool("lint_all_fail") {
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	lintCmd.AddCommand(allCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// allCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// allCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/lint_all.go
+++ b/cmd/lint_all.go
@@ -12,7 +12,9 @@ var allCmd = &cobra.Command{
 	Use:         "all",
 	Annotations: map[string]string{"rule-id": "none"},
 	Short:       "Run all lint commands.",
-	Long:        ``,
+	Long: `Allows running all lint commands at once.  This is not reccomended unless you have gone over 
+all available lint rules and configured those which are unwanted using a config file.
+To do this, you should set 'disable_rules:' within a yaml config file, and specify it using --config. `,
 	Run: func(cmd *cobra.Command, args []string) {
 		viper.Set("lint_all", true)
 		//RUn all commands with rule-id annotation.

--- a/cmd/lint_draft.go
+++ b/cmd/lint_draft.go
@@ -19,7 +19,9 @@ The check is designed to avoid drafts being enabled prior to the release of the 
 If draft: true, this lint rule will trigger a failure.  
 If draft: false, this lint rule will pass.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		evaluateRules(checkDraft)
+		if ruleEnabled("draft-enabled") {
+			evaluateRules(checkDraft)
+		}
 	},
 }
 

--- a/cmd/lint_tags.go
+++ b/cmd/lint_tags.go
@@ -23,8 +23,6 @@ var tagsCmd = &cobra.Command{
 	This command checks to ensure they are sorted alphabetically.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if ruleEnabled("tags-sorted") {
-			//recursively walk the "content" directory and find all the files
-			//that have a frontmatter
 			evaluateRules(checkTags)
 		}
 	},

--- a/cmd/lint_test.go
+++ b/cmd/lint_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 // All sub-commands added to the lintCmd
-// should have a rule-id annotation.  In the case that a  command does not have
+// should have a rule-id annotation.  In the case that a command does not have
 // a "categorizable" rule, rule-id should be annotated with "none".
 func Test_lintCmd_rule_id_annotations(t *testing.T) {
 	cmdList := lintCmd.Commands()

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -22,6 +22,9 @@ var listCmd = &cobra.Command{
 			if command.Annotations != nil {
 				//If command.Annotations has key "rule-id", print it
 				if _, ok := command.Annotations["rule-id"]; ok {
+					if command.Annotations["rule-id"] == "none" {
+						continue
+					}
 					fmt.Printf("%s \t\t %s \t\t %s\n", command.Name(), command.Annotations["rule-id"], command.Short)
 				}
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,9 +34,9 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "fmlint",
-	Short: "Lint your front-matter markdown files.",
-	Long: `Lint your front-matter markdown files.
-  For more information, try 'fmlint --help'.
+	Short: "Lint your markdown front-matter.",
+	Long: `Lint your markdown front-matter.
+For more information, try '--help' after any sub-command..
 
 `,
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ var rootCmd = &cobra.Command{
 	Use:   "fmlint",
 	Short: "Lint your markdown front-matter.",
 	Long: `Lint your markdown front-matter.
-For more information, try '--help' after any sub-command..
+For more information, try '--help' after any sub-command.
 
 `,
 


### PR DESCRIPTION
Introduce the `all` lint sub-command.  Allows running all lint commands at once.