### PR TITLE
fix: module versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/karldreher/fmlint
+module github.com/karldreher/fmlint/v2
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 package main
 
-import "github.com/karldreher/fmlint/cmd"
+import "github.com/karldreher/fmlint/v2/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
"Backwards compatible" fix under advisement of https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher.  This fixes the ability to install using `go install`.  (hopefully)