### PR TITLE
fix: imply enabled for individual rules, check at lint_all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default:
 	@ exit
 
 new-lint-rule:
-	@echo "Enter a new lint command name: "
+	@echo "Enter a new lint command name (camelCase): "
 	@read lintcmd; \
 	cobra-cli add $$lintcmd --parent lintCmd; \
 	mv cmd/$$lintcmd.go cmd/lint_$$lintcmd.go; \

--- a/cmd/lint_all.go
+++ b/cmd/lint_all.go
@@ -21,7 +21,11 @@ To do this, you should set 'disable_rules:' within a yaml config file, and speci
 		cmdList := lintCmd.Commands()
 		for _, command := range cmdList {
 			if command.Annotations["rule-id"] != "none" {
-				command.Run(cmd, args)
+				ruleId := command.Annotations["rule-id"]
+				// Only run the command if the rule is enabled.
+				if ruleEnabled(ruleId) {
+					command.Run(cmd, args)
+				}
 			}
 
 		}

--- a/cmd/lint_draft.go
+++ b/cmd/lint_draft.go
@@ -19,9 +19,7 @@ The check is designed to avoid drafts being enabled prior to the release of the 
 If draft: true, this lint rule will trigger a failure.  
 If draft: false, this lint rule will pass.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if ruleEnabled("draft-enabled") {
-			evaluateRules(checkDraft)
-		}
+		evaluateRules(checkDraft)
 	},
 }
 

--- a/cmd/lint_tagsMissing.go
+++ b/cmd/lint_tagsMissing.go
@@ -21,9 +21,7 @@ var tagsMissingCmd = &cobra.Command{
 	Long: `Tags in frontmatter are expected to be a YAML list.
 	This command checks to ensure at least one tag is present.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if ruleEnabled("tags-sorted") {
-			evaluateRules(checkTagsPresent)
-		}
+		evaluateRules(checkTagsPresent)
 	},
 }
 

--- a/cmd/lint_tags_sort.go
+++ b/cmd/lint_tags_sort.go
@@ -22,9 +22,7 @@ var tagsSortCmd = &cobra.Command{
 	Long: `Tags in frontmatter are expected to be a YAML list.
 	This command checks to ensure they are sorted alphabetically.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if ruleEnabled("tags-sorted") {
-			evaluateRules(checkTagSort)
-		}
+		evaluateRules(checkTagSort)
 	},
 }
 


### PR DESCRIPTION
While started as a refactor, it was observed that `disabled_rules` didn't work at all for at least one rule-id, so this is now a fix:.